### PR TITLE
Attachments refactor + optimización de queries en /index

### DIFF
--- a/app/Console/Commands/MigrateAttachmentsData.php
+++ b/app/Console/Commands/MigrateAttachmentsData.php
@@ -72,6 +72,8 @@ class MigrateAttachmentsData extends Command
                 Attachment::create($item);
             });
 
+        $this->info('Attachment data migrated succesfully.');
+
         return 0;
     }
 }

--- a/app/Console/Commands/MigrateAttachmentsData.php
+++ b/app/Console/Commands/MigrateAttachmentsData.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Attachment;
+use App\Models\CommentAttachment;
+use App\Models\Post;
+use App\Models\PostAttachment;
+use Illuminate\Console\Command;
+
+class MigrateAttachmentsData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'migrate_attachments_data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate the data from PostAttachment and CommentAttachment models to the Attachment model';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        PostAttachment::unguard(true);
+
+        PostAttachment::all()
+            ->map(function (PostAttachment $attachment) {
+                return [
+                    'attachable_id' => $attachment->post_id,
+                    'attachable_type' => 'App\Models\Post',
+                    'url' => $attachment->url,
+                    'created_at' => $attachment->created_at,
+                    'updated_at' => $attachment->updated_at,
+                ];
+            })->each(function ($item) {
+                Attachment::create($item);
+            });
+
+        CommentAttachment::unguard(true);
+
+        CommentAttachment::all()
+            ->map(function (CommentAttachment $attachment) {
+                return [
+                    'attachable_id' => $attachment->comment_id,
+                    'attachable_type' => 'App\Models\Comment',
+                    'url' => $attachment->url,
+                    'created_at' => $attachment->created_at,
+                    'updated_at' => $attachment->updated_at,
+                ];
+            })
+            ->each(function ($item) {
+                Attachment::create($item);
+            });
+
+        return 0;
+    }
+}

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Attachment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'attachable_id',
+        'attachable_type',
+        'url',
+    ];
+
+    public function attachable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -24,8 +24,16 @@ class Comment extends Model
         return $this->belongsTo(Post::class);
     }
 
+    public function attachments()
+    {
+        return $this->morphMany(Attachment::class, 'attachable');
+    }
+
+    /**
+     * @deprecated please use `attachments()`
+     */
     public function comment_attachments()
     {
-        return $this->hasMany(CommentAttachment::class);
+        return $this->attachments();
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -30,8 +30,16 @@ class Post extends Model
         return $this->hasMany(Comment::class);
     }
 
+    public function attachments()
+    {
+        return $this->morphMany(Attachment::class, 'attachable');
+    }
+
+    /**
+     * @deprecated please use `attachments()`
+     */
     public function post_attachments()
     {
-        return $this->hasMany(PostAttachment::class);
+        return $this->attachments();
     }
 }

--- a/database/migrations/2021_09_06_180259_create_attachments_table.php
+++ b/database/migrations/2021_09_06_180259_create_attachments_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAttachmentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('attachments', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('attachable_id');
+            $table->string('attachable_type');
+            $table->string('url');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('attachments');
+    }
+}

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -14,8 +14,8 @@
                 <th>
                     Comments
                 </th>
-                <th> Comment Attachments
-
+                <th>
+                    Comment Attachments
                 </th>
             </tr>
         </thead>
@@ -32,11 +32,7 @@
                         {{ $post->comments_count }}
                     </td>
                     <td>
-                        {{
-                            $post->comments->reduce(function ($carry, $comment) {
-                                return $carry + $comment->attachments_count;
-                            })
-                        }}
+                        {{ $post->comments->sum('attachments_count') }}
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -26,7 +26,7 @@
                         {{ $post->title }}
                     </td>
                     <td>
-                        {{ $post->post_attachments_count }}
+                        {{ $post->attachments_count }}
                     </td>
                     <td>
                         {{ $post->comments_count }}
@@ -34,7 +34,7 @@
                     <td>
                         {{
                             $post->comments->reduce(function ($carry, $comment) {
-                                return $carry + $comment->comment_attachments_count;
+                                return $carry + $comment->attachments_count;
                             })
                         }}
                     </td>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -26,15 +26,17 @@
                         {{ $post->title }}
                     </td>
                     <td>
-                        {{ $post->post_attachments()->count() }}
+                        {{ $post->post_attachments_count }}
                     </td>
                     <td>
-                        {{ $post->comments()->count() }}
+                        {{ $post->comments_count }}
                     </td>
                     <td>
-                        {{ $post->comments->reduce(function ($carry, $comment) {
-    return $carry + $comment->comment_attachments()->count();
-}) }}
+                        {{
+                            $post->comments->reduce(function ($carry, $comment) {
+                                return $carry + $comment->comment_attachments_count;
+                            })
+                        }}
                     </td>
                 </tr>
             @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,21 @@ Route::get('/', function () {
 });
 
 Route::get('index', function () {
+    $users = \App\Models\User::query()
+        ->with([
+            'posts' => function ($query) {
+                $query->withCount('post_attachments');
+                $query->withCount('comments');
+            },
+            'posts.comments' => function ($query) {
+                $query->withCount('comment_attachments');
+            },
+            'posts.post_attachments',
+            'posts.comments.comment_attachments',
+        ])
+        ->get();
+
     return view('index', [
-        'users' => \App\Models\User::all()
+        'users' => $users
     ]);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,14 +21,14 @@ Route::get('index', function () {
     $users = \App\Models\User::query()
         ->with([
             'posts' => function ($query) {
-                $query->withCount('post_attachments');
+                $query->withCount('attachments');
                 $query->withCount('comments');
             },
             'posts.comments' => function ($query) {
-                $query->withCount('comment_attachments');
+                $query->withCount('attachments');
             },
-            'posts.post_attachments',
-            'posts.comments.comment_attachments',
+            'posts.attachments',
+            'posts.comments.attachments',
         ])
         ->get();
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,8 +27,6 @@ Route::get('index', function () {
             'posts.comments' => function ($query) {
                 $query->withCount('attachments');
             },
-            'posts.attachments',
-            'posts.comments.attachments',
         ])
         ->get();
 


### PR DESCRIPTION
# Ejercicio 1

Se sustituyeron las clases `PostAttachment` y `CommentAttachment` por una única clase llamada `Attachment`, se definió una nueva relación `attachments()` en las clases `Post` y `Comment` respectivamente.

Se definió un comando `migrate_attachments_data` el cual debe ser ejecutado para migrar la data de las tablas a la nueva estructura. Durante esta migración se conservan el 100% de los datos, incluyendo los timestamps originales (`created_at` y `updated_at`).

Para realizar satisfactoriamente esta migración de datos es necesario ejecutar los siguientes comandos:

Para ejecutar la miragación `CreateAttachmentsTable`:
```bash
php artisan migrate
```

Para mover toda la data antigua a la nueva tabla:
```bash
php artisan migrate_attachments_data
```

# Ejercicio 2

Se realizó un Eager Loading de las relaciones `posts`, `posts.attachments`, `posts.comments` y `posts.comments.attachments` para que al momento de estos elementos ser presentados en la vista ya estén cargados en memoria y no sea necesario realizar nueva consultas.

Al mismo tiempo, se realiza una cuenta de los elementos de estas relaciones, los cuales son mostrados en la ruta `/index` como una lista de Posts de cada usuario en la BD.

Con estos cambios podemos notar una reducción en la cantidad de queries. 

Pasamos de tener 656 queries para obtener la data de la vista
![image](https://user-images.githubusercontent.com/13445515/132270400-2a8d8261-0ba5-432e-87ce-052fbe1d2f7c.png)

A realizar solamente 5 queries para obtener toda la data necesaria desde la BD.
El realizar una menor cantidad de queries a la BD, reduce el tiempo de respuesta en al menos ~100ms.
![image](https://user-images.githubusercontent.com/13445515/132270467-f3b1b48d-fcd1-462c-bff3-270a4365e46b.png)

Sin embargo estos cambios ocasionas un mayor uso de memoria debido a que la cantidad de modelos cargados en memoria aumenta de 555 a 9705, lo cual debe ser tomado en consideración a la hora de escalar.
![image](https://user-images.githubusercontent.com/13445515/132270723-c3c891aa-521a-49bf-9f56-8cc526cfa950.png)

Estos valores fueron tomados con las siguientes especificaciones:
Windows 11 Build 22000.176
PHP 7.4.19 x64
Ryzen 5 5600G
16GB RAM
